### PR TITLE
Itemnotfound exception on remove method

### DIFF
--- a/src/ios/SecureStorage.m
+++ b/src/ios/SecureStorage.m
@@ -83,8 +83,16 @@
 
     if ([query deleteItem:&error]) {
         [self successWithMessage: key];
-    } else {
-        [self failWithMessage: @"Failure in SecureStorage.get()" withError: error];
+    } 
+    else {
+        //Se setea esto como excepcion ya que si no encuentra el registro implica que está eliminado
+        if([error code] == errSecItemNotFound){
+            [self successWithMessage:key];
+        }
+        else{
+            [self failWithMessage: @"Failure in SecureStorage.get()" withError: error];
+        }
+        
     }
 }
 


### PR DESCRIPTION
Se ha añadido una excepción cuando se elimina un registro del keychain y este arroja un error tipo "Item not Found" para que el plugin realice un successCallback en vez de errorCallback
